### PR TITLE
Configurable RPC lines

### DIFF
--- a/utils/rpc.js
+++ b/utils/rpc.js
@@ -13,8 +13,6 @@ switch(appTitle){
 const client = require('discord-rich-presence')(clientId);
 const lang = require('./lang');
 exports = module.exports = {};
-const Store = require('electron-store');
-const store = new Store();
 
 exports.setStatus = function(currentTrack){
     switch (currentTrack.playerState) {

--- a/utils/rpc.js
+++ b/utils/rpc.js
@@ -52,7 +52,7 @@ const composeLine1 = function(currentTrack) {
 
     return line1 != null
         ? replacePartsInLine(line1, currentTrack)
-        : `▶ ${lang.get.listeningto} ${currentTrack.name} ${lang.get.by} ${currentTrack.artist}`;
+        : `🎵 ${lang.get.listeningto} ${currentTrack.name} ${lang.get.by} ${currentTrack.artist}`;
 }
 
 const composeLine2 = function(currentTrack) {

--- a/utils/rpc.js
+++ b/utils/rpc.js
@@ -1,7 +1,8 @@
 const client = require('discord-rich-presence')('420530637485637644');
 const lang = require('./lang')
 exports = module.exports = {};
-
+const Store = require('electron-store');
+const store = new Store();
 
 exports.setStatus = function(currentTrack){
     switch (currentTrack.playerState) {
@@ -47,15 +48,17 @@ exports.disconnectRpc = function() {
 };
 
 const composeLine1 = function(currentTrack) {
-    const line1 = '%song%'; // how to get from config.json?
-    return line1.length
+    const line1 = store.get('line-1');
+
+    return line1 != null
         ? replacePartsInLine(line1, currentTrack)
         : `▶ ${lang.get.listeningto} ${currentTrack.name} ${lang.get.by} ${currentTrack.artist}`;
 }
 
 const composeLine2 = function(currentTrack) {
-    const line2 = 'by %artist% on %album%'; // how to get from config.json?
-    return line2.length
+    const line2 = store.get('line-2');
+
+    return line2 != null
         ? replacePartsInLine(line2, currentTrack)
         : `💿 ${currentTrack.album}`;
 }

--- a/utils/rpc.js
+++ b/utils/rpc.js
@@ -7,13 +7,27 @@ exports.setStatus = function(currentTrack){
     switch (currentTrack.playerState) {
         case "playing": {
             const time = new Date();
-            const presence = {details: "▶ "+lang.get.listeningto+" "+currentTrack.name+" "+lang.get.by+" "+currentTrack.artist, state: "💿 "+currentTrack.album, largeImageKey: 'itunes_large', smallImageKey: 'playing',startTimestamp: time,  endTimestamp: new Date(time.getTime() + (currentTrack.remainingTime * 1000)), instance: false};
+            const presence = {
+                details: composeLine1(currentTrack),
+                state: composeLine2(currentTrack),
+                largeImageKey: 'itunes_large',
+                smallImageKey: 'playing',
+                startTimestamp: time,
+                endTimestamp: new Date(time.getTime() + (currentTrack.remainingTime * 1000)),
+                instance: false
+            };
             client.updatePresence(presence);
             console.log("Sent player informations to rpc!");
             break;
         }
         case "paused": {
-            const presence = {details: "❙❙ "+lang.get.paused+" "+currentTrack.name+" "+lang.get.by+" "+currentTrack.artist, state: "💿 "+currentTrack.album, largeImageKey: 'itunes_large', smallImageKey: 'paused', instance: false};
+            const presence = {
+                details: composeLine1(currentTrack),
+                state: composeLine2(currentTrack),
+                largeImageKey: 'itunes_large',
+                smallImageKey: 'paused',
+                instance: false
+            };
             client.updatePresence(presence);
             console.log("Sent player informations to rpc!");
             break;
@@ -31,3 +45,24 @@ exports.setStatus = function(currentTrack){
 exports.disconnectRpc = function() {
     client.disconnect();
 };
+
+const composeLine1 = function(currentTrack) {
+    const line1 = '%song%'; // how to get from config.json?
+    return line1.length
+        ? replacePartsInLine(line1, currentTrack)
+        : `▶ ${lang.get.listeningto} ${currentTrack.name} ${lang.get.by} ${currentTrack.artist}`;
+}
+
+const composeLine2 = function(currentTrack) {
+    const line2 = 'by %artist% on %album%'; // how to get from config.json?
+    return line2.length
+        ? replacePartsInLine(line2, currentTrack)
+        : `💿 ${currentTrack.album}`;
+}
+
+const replacePartsInLine = function(line, currentTrack) {
+    return line
+        .replace('%song%', currentTrack.name)
+        .replace('%artist%', currentTrack.artist)
+        .replace('%album%', currentTrack.album);
+}

--- a/utils/settings.js
+++ b/utils/settings.js
@@ -1,6 +1,6 @@
 const {ipcMain, app} = require('electron');
 const Store = require('electron-store');
-const defaultConfig = {"launch-at-login": true, "language": "english"};
+const defaultConfig = {"launch-at-login": true, "language": "english", "line-1": null, "line-2": null};
 const store = new Store({defaults: defaultConfig});
 const open = require('open');
 


### PR DESCRIPTION
Add ability for user to define configurable RPC lines via `line1` and `line2` in config.json.  Example...

```
{
    "launch-at-login": true,
    "language": "english",
    "line-1": "%song%",
    "line-2": "by %artist% on %album%"
}
```

It will string replace `%song%`, `%artist%`, and `%album%` when it composes the lines for presence.  If those lines are left `null` in the config, it will default to how it composes those lines right now 👍 

...Just a starting point, feel free to clean up my mess if you merge 💖